### PR TITLE
Add True Freeze

### DIFF
--- a/frontend/lib/stores/BountyProgramsStore.ts
+++ b/frontend/lib/stores/BountyProgramsStore.ts
@@ -37,6 +37,11 @@ const programs = [
     slug: "uniswap",
     bountyProgramID: "f6d8778a-6f1d-b643-5661-b1ca97f391ed",
   },
+  {
+    name: "True Freeze",
+    slug: "true-freeze",
+    bountyProgramID: "24c602b5-a202-9c05-4465-5b0d37132401",
+  },
 ];
 
 export const useBountyProgramStore = create<BountyProgramState>((set: any) => ({


### PR DESCRIPTION
Adding True Freeze canny.io board to support launch of "True Freeze" bounties. The `bountyProgramID` is the extracted from `"token": "24c602b5-a202-9c05-4465-5b0d37132401",` of `"true-freeze":` board from https://metricsdao.canny.io/admin/settings/boards/true-freeze/general