### PR TITLE
configurable header description and hint for bounty programs

### DIFF
--- a/frontend/lib/stores/BountyProgramsStore.ts
+++ b/frontend/lib/stores/BountyProgramsStore.ts
@@ -41,11 +41,15 @@ const programs = [
     name: "Goldfinch",
     slug: "goldfinch",
     bountyProgramID: "c1af1118-3163-a6b3-4b67-fc73ef7ff008",
-    customTitle: "This is My Custom Title for Goldfinch",
+  },
+  {
+    name: "Report Plagiarism",
+    slug: "report-submission",
+    bountyProgramID: "49927eef-fe6e-c39b-f1e6-012ab4bb9a2d",
+    customTitle: "Report Plagiarized Submissions",
     customDescription:
-      "This is My Custom Description for Goldfinch 🚀 Try a really long sentence and insert paragraph breaks how they will appear to see if this really works or if we need to insert breaks ourself.\n\nHere is a second paragraph.",
-    customHint: "This is My Custom Hint for Goldfinch 👀",
-    hintLink: "https://metricsdao.xyz/",
+      "Is your work plagiarized by another analyst? Please use the form below and report them.",
+    disableHint: true,
   },
 ];
 

--- a/frontend/lib/stores/BountyProgramsStore.ts
+++ b/frontend/lib/stores/BountyProgramsStore.ts
@@ -4,6 +4,9 @@ export interface BountyProgram {
   name: string;
   slug: string;
   bountyProgramID: string;
+  customTitle?: string;
+  customDescription?: string;
+  customHint?: string;
 }
 export interface BountyProgramState {
   programs: BountyProgram[];
@@ -12,7 +15,6 @@ export interface BountyProgramState {
 }
 
 const programs = [
-  
   {
     name: "Aave v3",
     slug: "aave-v3",
@@ -37,7 +39,7 @@ const programs = [
     name: "Goldfinch",
     slug: "goldfinch",
     bountyProgramID: "c1af1118-3163-a6b3-4b67-fc73ef7ff008",
-  }
+  },
 ];
 
 export const useBountyProgramStore = create<BountyProgramState>((set: any) => ({

--- a/frontend/lib/stores/BountyProgramsStore.ts
+++ b/frontend/lib/stores/BountyProgramsStore.ts
@@ -7,6 +7,8 @@ export interface BountyProgram {
   customTitle?: string;
   customDescription?: string;
   customHint?: string;
+  hintLink?: string;
+  disableHint?: boolean;
 }
 export interface BountyProgramState {
   programs: BountyProgram[];
@@ -39,6 +41,11 @@ const programs = [
     name: "Goldfinch",
     slug: "goldfinch",
     bountyProgramID: "c1af1118-3163-a6b3-4b67-fc73ef7ff008",
+    customTitle: "This is My Custom Title for Goldfinch",
+    customDescription:
+      "This is My Custom Description for Goldfinch 🚀 Try a really long sentence and insert paragraph breaks how they will appear to see if this really works or if we need to insert breaks ourself.\n\nHere is a second paragraph.",
+    customHint: "This is My Custom Hint for Goldfinch 👀",
+    hintLink: "https://metricsdao.xyz/",
   },
 ];
 

--- a/frontend/pages/bounty-programs/[bountyProgramSlug]/index.tsx
+++ b/frontend/pages/bounty-programs/[bountyProgramSlug]/index.tsx
@@ -12,6 +12,9 @@ import {
   ModalContent,
   ModalFooter,
   useDisclosure,
+  Wrap,
+  WrapItem,
+  Center,
 } from "@chakra-ui/react";
 import { CannyWidget } from "../../../lib/components/CannyWidget";
 import { useRouter } from "next/dist/client/router";
@@ -52,6 +55,9 @@ const BountyPrograms: NextPage = () => {
     return <></>;
   }
 
+  console.log("DESCRIPTION", bountyProgram.customDescription);
+  console.log("TITLE", bountyProgram.customTitle);
+
   return (
     <Box width="100%">
       <Box
@@ -60,28 +66,57 @@ const BountyPrograms: NextPage = () => {
         padding="15px"
         borderRadius="4px"
       >
-        <Heading fontSize="lg" fontFamily="mono">
-          🕵️‍♀️ {bountyProgram.name} Bounty Question Proposals
-        </Heading>
-        <Text fontFamily="mono" fontSize="sm">
-          <br />A space to propose and gather questions relevant to{" "}
-          {bountyProgram.name}. What do you want to know about{" "}
-          {bountyProgram.name}? Questions defined, and ranked here will form the
-          basis of future Analytics Bounties by MetricsDAO!
-          <br />
-          <br />
-          See a question you want answered? Upvote it! 
-        </Text>
-        <Button
-          marginTop="15px"
-          variant="secondary"
-          onClick={() => {
-            mixpanel.track("click:bounty_question_tips");
-            onOpen();
-          }}
-        >
-          🤔 How to Write a Good Question (click me to learn) 🤔
-        </Button>
+        {bountyProgram.customTitle == undefined ? (
+          <Heading fontSize="lg" fontFamily="mono">
+            🕵️‍♀️ {bountyProgram.name} Bounty Question Proposals
+          </Heading>
+        ) : (
+          <Heading fontSize="lg" fontFamily="mono">
+            🕵️‍♀️ {bountyProgram.customTitle}
+          </Heading>
+        )}
+        {bountyProgram.customDescription == undefined ? (
+          <Text fontFamily="mono" fontSize="sm">
+            <br />A space to propose and gather questions relevant to{" "}
+            {bountyProgram.name}. What do you want to know about{" "}
+            {bountyProgram.name}? Questions defined, and ranked here will form
+            the basis of future Analytics Bounties by MetricsDAO!
+            <br />
+            <br />
+            See a question you want answered? Upvote it!
+          </Text>
+        ) : (
+          <Text fontFamily="mono" fontSize="sm">
+            <br />
+            {bountyProgram.customDescription}
+          </Text>
+        )}
+        {bountyProgram.customHint == undefined ? (
+          <WrapItem>
+            <Button
+              fontSize={["xs", "sm"]}
+              marginTop="15px"
+              variant="secondary"
+              onClick={() => {
+                mixpanel.track("click:bounty_question_tips");
+                onOpen();
+              }}
+            >
+              🤔 How to Write a Good Question (click me to learn) 🤔
+            </Button>
+          </WrapItem>
+        ) : (
+          <Button
+            marginTop="15px"
+            variant="secondary"
+            onClick={() => {
+              mixpanel.track("click:bounty_question_tips");
+              onOpen();
+            }}
+          >
+            {bountyProgram.customHint}
+          </Button>
+        )}
       </Box>
       <Box>
         {counter != 1 && (

--- a/frontend/pages/bounty-programs/[bountyProgramSlug]/index.tsx
+++ b/frontend/pages/bounty-programs/[bountyProgramSlug]/index.tsx
@@ -12,9 +12,7 @@ import {
   ModalContent,
   ModalFooter,
   useDisclosure,
-  Wrap,
   WrapItem,
-  Center,
 } from "@chakra-ui/react";
 import { CannyWidget } from "../../../lib/components/CannyWidget";
 import { useRouter } from "next/dist/client/router";
@@ -54,9 +52,6 @@ const BountyPrograms: NextPage = () => {
     window.location.assign("/");
     return <></>;
   }
-
-  console.log("DESCRIPTION", bountyProgram.customDescription);
-  console.log("TITLE", bountyProgram.customTitle);
 
   return (
     <Box width="100%">

--- a/frontend/pages/bounty-programs/[bountyProgramSlug]/index.tsx
+++ b/frontend/pages/bounty-programs/[bountyProgramSlug]/index.tsx
@@ -81,12 +81,19 @@ const BountyPrograms: NextPage = () => {
             See a question you want answered? Upvote it!
           </Text>
         ) : (
-          <Text fontFamily="mono" fontSize="sm">
+          <Text
+            whiteSpace="pre-line"
+            id="customDescription"
+            fontFamily="mono"
+            fontSize="sm"
+          >
             <br />
             {bountyProgram.customDescription}
           </Text>
         )}
-        {bountyProgram.customHint == undefined ? (
+        {bountyProgram.customHint == undefined &&
+        (bountyProgram.disableHint == undefined ||
+          bountyProgram.disableHint == false) ? (
           <WrapItem>
             <Button
               fontSize={["xs", "sm"]}
@@ -101,19 +108,23 @@ const BountyPrograms: NextPage = () => {
             </Button>
           </WrapItem>
         ) : (
-          <WrapItem>
-            <Button
-              fontSize={["xs", "sm"]}
-              marginTop="15px"
-              variant="secondary"
-              onClick={() => {
-                mixpanel.track("click:bounty_question_tips");
-                onOpen();
-              }}
-            >
-              {bountyProgram.customHint}
-            </Button>
-          </WrapItem>
+          (bountyProgram.disableHint == undefined ||
+            bountyProgram.disableHint == false) && (
+            <WrapItem>
+              <Button
+                fontSize={["xs", "sm"]}
+                marginTop="15px"
+                variant="secondary"
+                onClick={() => {
+                  bountyProgram.hintLink
+                    ? window.open(bountyProgram.hintLink)
+                    : onOpen();
+                }}
+              >
+                {bountyProgram.customHint}
+              </Button>
+            </WrapItem>
+          )
         )}
       </Box>
       <Box>

--- a/frontend/pages/bounty-programs/[bountyProgramSlug]/index.tsx
+++ b/frontend/pages/bounty-programs/[bountyProgramSlug]/index.tsx
@@ -101,16 +101,19 @@ const BountyPrograms: NextPage = () => {
             </Button>
           </WrapItem>
         ) : (
-          <Button
-            marginTop="15px"
-            variant="secondary"
-            onClick={() => {
-              mixpanel.track("click:bounty_question_tips");
-              onOpen();
-            }}
-          >
-            {bountyProgram.customHint}
-          </Button>
+          <WrapItem>
+            <Button
+              fontSize={["xs", "sm"]}
+              marginTop="15px"
+              variant="secondary"
+              onClick={() => {
+                mixpanel.track("click:bounty_question_tips");
+                onOpen();
+              }}
+            >
+              {bountyProgram.customHint}
+            </Button>
+          </WrapItem>
         )}
       </Box>
       <Box>


### PR DESCRIPTION
This is for ticket https://github.com/MetricsDAO/bounty_app/issues/13. 

Adds the ability to configure custom titles, descriptions, and hints for bounty programs. 

Also fixes a mobile styling issue 

![Screen Shot 2022-09-12 at 5 40 25 PM](https://user-images.githubusercontent.com/43100701/189764208-25b883d9-b465-47cb-b77b-1ba038fea8c4.png)
------>
![Screen Shot 2022-09-12 at 5 40 33 PM](https://user-images.githubusercontent.com/43100701/189764218-5423d014-7f18-4fe8-b389-1e6f51463f43.png)

