### PR TITLE
fix styling for hint button

### DIFF
--- a/frontend/pages/bounty-programs/[bountyProgramSlug]/index.tsx
+++ b/frontend/pages/bounty-programs/[bountyProgramSlug]/index.tsx
@@ -12,7 +12,6 @@ import {
   ModalContent,
   ModalFooter,
   useDisclosure,
-  WrapItem,
 } from "@chakra-ui/react";
 import { CannyWidget } from "../../../lib/components/CannyWidget";
 import { useRouter } from "next/dist/client/router";
@@ -112,7 +111,6 @@ const BountyPrograms: NextPage = () => {
             </Text>
           </Button>
         ) : (
-          // </WrapItem>
           (bountyProgram.disableHint == undefined ||
             bountyProgram.disableHint == false) && (
             <Button

--- a/frontend/pages/bounty-programs/[bountyProgramSlug]/index.tsx
+++ b/frontend/pages/bounty-programs/[bountyProgramSlug]/index.tsx
@@ -94,36 +94,43 @@ const BountyPrograms: NextPage = () => {
         {bountyProgram.customHint == undefined &&
         (bountyProgram.disableHint == undefined ||
           bountyProgram.disableHint == false) ? (
-          <WrapItem>
+          <Button
+            height="auto"
+            width="100%"
+            whiteSpace="normal"
+            overflowWrap="break-word"
+            fontSize={["sm"]}
+            marginTop="15px"
+            variant="secondary"
+            onClick={() => {
+              mixpanel.track("click:bounty_question_tips");
+              onOpen();
+            }}
+          >
+            <Text padding={2}>
+              🤔 How to Write a Good Question (click me to learn) 🤔{" "}
+            </Text>
+          </Button>
+        ) : (
+          // </WrapItem>
+          (bountyProgram.disableHint == undefined ||
+            bountyProgram.disableHint == false) && (
             <Button
-              fontSize={["xs", "sm"]}
+              height="auto"
+              width="100%"
+              whiteSpace="normal"
+              overflowWrap="break-word"
+              fontSize={["sm"]}
               marginTop="15px"
               variant="secondary"
               onClick={() => {
-                mixpanel.track("click:bounty_question_tips");
-                onOpen();
+                bountyProgram.hintLink
+                  ? window.open(bountyProgram.hintLink)
+                  : onOpen();
               }}
             >
-              🤔 How to Write a Good Question (click me to learn) 🤔
+              <Text padding={2}>{bountyProgram.customHint}</Text>
             </Button>
-          </WrapItem>
-        ) : (
-          (bountyProgram.disableHint == undefined ||
-            bountyProgram.disableHint == false) && (
-            <WrapItem>
-              <Button
-                fontSize={["xs", "sm"]}
-                marginTop="15px"
-                variant="secondary"
-                onClick={() => {
-                  bountyProgram.hintLink
-                    ? window.open(bountyProgram.hintLink)
-                    : onOpen();
-                }}
-              >
-                {bountyProgram.customHint}
-              </Button>
-            </WrapItem>
           )
         )}
       </Box>


### PR DESCRIPTION
This mobile styling on the hint button was still off and bothering me, this should work. 

It currently looks like this: 

![Screen Shot 2022-09-16 at 11 15 11 AM](https://user-images.githubusercontent.com/43100701/190673405-c558ef01-820b-4917-951f-1b643b202682.png)


fix does this: 

![Screen Shot 2022-09-16 at 11 15 03 AM](https://user-images.githubusercontent.com/43100701/190673352-09db8792-0bee-460d-a477-f2a7b8a851b2.png)

